### PR TITLE
Faster implementation

### DIFF
--- a/addon/components/skeleton-img.js
+++ b/addon/components/skeleton-img.js
@@ -7,53 +7,42 @@ const {
 } = Ember;
 
 export default Ember.Component.extend({
-  setupSrcs: on('init', function() {
-    set(this, 'actualSrc', get(this, 'src'));
+  setup: on('init', function() {
+    set(this, 'imgBindings', {
+      load: this.load.bind(this),
+      error: this.error.bind(this)
+    });
+
+    this.setupActualImg();
+
     set(this, 'src', get(this, 'tmpSrc'));
     set(this, 'loadState', 'loading');
   }),
-  setupImgBindings: on('init', function() {
-    set(this, 'imgBindings', {
-      loadTmp: this.loadTmp.bind(this),
-      loadActual: this.loadActual.bind(this),
-      errorActual: this.errorActual.bind(this)
-    });
-  }),
+  setupActualImg() {
+    let img = new Image();
+    img.addEventListener('load', get(this, 'imgBindings.load'));
+    img.addEventListener('error', get(this, 'imgBindings.error'));
+    img.src = get(this, 'src');
+    set(this, 'actualImg', img);
+  },
   classNames: ['skeleton-img'],
   classNameBindings: ['loadState'],
   tagName: 'img',
   attributeBindings: [
     'src'
   ],
-  didInsertElement() {
-    let target = this.element;
-    let loadTmp = get(this, 'imgBindings.loadTmp');
-    target.addEventListener('load', loadTmp);
-  },
-  loadTmp(event) {
-    let target = event.target;
-    let loadTmp = get(this, 'imgBindings.loadTmp');
-    let loadActual = get(this, 'imgBindings.loadActual');
-    let errorActual = get(this, 'imgBindings.errorActual');
-    target.removeEventListener('load', loadTmp);
-    target.addEventListener('load', loadActual);
-    target.addEventListener('error', errorActual);
-    set(this, 'src', get(this, 'actualSrc'));
-  },
-  loadActual(event) {
+  load() {
+    let actualImg = get(this, 'actualImg');
     set(this, 'loadState', 'loaded');
-    this.removeEvents(event.target);
+    set(this, 'src', actualImg.src);
   },
-  errorActual(event) {
+  error() {
     let errorSrc = get(this, 'errorSrc') || get(this, 'tmpSrc');
-    this.removeEvents(event.target);
-    set(this, 'src', errorSrc);
+
+    if (errorSrc !== get(this, 'src')) {
+      set(this, 'src', errorSrc);
+    }
+
     set(this, 'loadState', 'load-error');
   },
-  removeEvents(target) {
-    let loadActual = get(this, 'imgBindings.loadActual');
-    let errorActual = get(this, 'imgBindings.errorActual');
-    target.removeEventListener('load', loadActual);
-    target.removeEventListener('error', errorActual);
-  }
 });


### PR DESCRIPTION
Rather than wait until the tmpSrc is loaded before loading the src
we are now instantiating a virtual Image object and setting its src to
the target src path. This will async load the src. All events are
attached to the virtual object and handled there.

tldr; cleaner and faster