### PR TITLE
Defer rendering

### DIFF
--- a/addon/components/skeleton-img.js
+++ b/addon/components/skeleton-img.js
@@ -3,26 +3,36 @@ import Ember from 'ember';
 const {
   set,
   get,
-  on
+  on,
+  addObserver,
+  removeObserver
 } = Ember;
 
 export default Ember.Component.extend({
+  renderSrc: true,
   setup: on('init', function() {
     set(this, 'imgBindings', {
       load: this.load.bind(this),
-      error: this.error.bind(this)
+      error: this.error.bind(this),
+      setup: this.setupActualImg.bind(this)
     });
 
-    this.setupActualImg();
-
+    set(this, 'actualSrc', get(this, 'src'));
     set(this, 'src', get(this, 'tmpSrc'));
     set(this, 'loadState', 'loading');
+
+    if(get(this, 'renderSrc')) {
+      this.setupActualImg();
+    } else {
+      addObserver(this, 'renderSrc', get(this, 'imgBindings.setup'));
+    }
   }),
   setupActualImg() {
     let img = new Image();
     img.addEventListener('load', get(this, 'imgBindings.load'));
     img.addEventListener('error', get(this, 'imgBindings.error'));
-    img.src = get(this, 'src');
+    removeObserver(this, 'renderSrc', get(this, 'imgBindings.setup'));
+    img.src = get(this, 'actualSrc');
     set(this, 'actualImg', img);
   },
   classNames: ['skeleton-img'],

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-in-viewport": "1.2.3",
     "ember-try": "0.0.4"
   },
   "keywords": [

--- a/tests/dummy/app/components/viewport-skeleton-img.js
+++ b/tests/dummy/app/components/viewport-skeleton-img.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import SkeletonImg from 'ember-skeleton/components/skeleton-img';
+import InViewportMixin from 'ember-in-viewport';
+
+const {
+  set,
+  on
+} = Ember;
+
+export default SkeletonImg.extend(InViewportMixin, {
+  renderSrc: false,
+  didEnterViewport() {
+    set(this, 'renderSrc', true);
+  },
+  classNames: ['viewport-skeleton'],
+  viewportOptionsOverride: on('didInsertElement', function() {
+    let half = this.element.getBoundingClientRect().height / 2;
+    set(this, 'viewportTolerance', {
+      top: half,
+      bottom: half,
+      left: 0,
+      right: 0
+    });
+  })
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,5 @@ var Router = Ember.Router.extend({
 });
 
 export default Router.map(function() {
+  this.route('in-viewport');
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,4 +1,6 @@
 .skeleton-img {
+  display: block;
+  margin-top: 300px;
   width: 300px;
   height: 200px;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,1 @@
-{{skeleton-img src="http://boatingtimesli.com/NY/wp-content/uploads/2012/08/Sandy-doggie-from-Jessica-Wurzbacher.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
-{{skeleton-img src="http://hallak.com/wp-content/uploads/2014/04/cute-dog-dogs.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
-{{skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-Roma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
-{{skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-oma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://img2.wikia.nocookie.net/__cb20100427134246/half-life/en/images/b/b8/Error.jpg"}}
+{{outlet}}

--- a/tests/dummy/app/templates/in-viewport.hbs
+++ b/tests/dummy/app/templates/in-viewport.hbs
@@ -1,0 +1,5 @@
+{{link-to 'On Load Rendering' 'index'}}
+{{viewport-skeleton-img src="http://boatingtimesli.com/NY/wp-content/uploads/2012/08/Sandy-doggie-from-Jessica-Wurzbacher.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{viewport-skeleton-img src="http://hallak.com/wp-content/uploads/2014/04/cute-dog-dogs.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{viewport-skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-Roma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{viewport-skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-oma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://img2.wikia.nocookie.net/__cb20100427134246/half-life/en/images/b/b8/Error.jpg"}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,5 @@
+{{link-to 'In Viewport Rendering' 'in-viewport'}}
+{{skeleton-img src="http://boatingtimesli.com/NY/wp-content/uploads/2012/08/Sandy-doggie-from-Jessica-Wurzbacher.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{skeleton-img src="http://hallak.com/wp-content/uploads/2014/04/cute-dog-dogs.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-Roma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://www.fillmurray.com/g/400/250"}}
+{{skeleton-img src="http://www.dogsforthedisabled.org/wp-content/uploads/2010/11/Ramzi-oma-Romo-Rio-Ringo.jpg" tmpSrc="http://placehold.it/300x200" errorSrc="http://img2.wikia.nocookie.net/__cb20100427134246/half-life/en/images/b/b8/Error.jpg"}}


### PR DESCRIPTION
The default is for the render to occur on load, but an optional override
for `renderSrc` can be passed into each component. This works nicely
with `ember-in-viewport`